### PR TITLE
Add GroupsOrPlaceholder sorting type

### DIFF
--- a/.github/wiki/feature_guide_sorting.md
+++ b/.github/wiki/feature_guide_sorting.md
@@ -8,6 +8,7 @@
   * [PLACEHOLDER_Z_TO_A](#placeholder_z_to_a)
   * [PLACEHOLDER_LOW_TO_HIGH](#placeholder_low_to_high)
   * [PLACEHOLDER_HIGH_TO_LOW](#placeholder_high_to_low)
+  * [GROUPS_OR_PLACEHOLDER](#groups_or_placeholder)
 * [Multiple elements with the same priority](#multiple-elements-with-the-same-priority)
 * [Combining multiple sorting types](#combining-multiple-sorting-types)
 * [Additional settings](#additional-settings)
@@ -122,7 +123,7 @@ scoreboard-teams:
 ```
 
 ## PLACEHOLDER_HIGH_TO_LOW
-This method sorts players numerically depending on the output of a **numeric** placeholder from the highest value to the lowest value.  
+This method sorts players numerically depending on the output of a **numeric** placeholder from the highest value to the lowest value.
 **Only placeholders that output number values will work with this sorting type!**  
 Supported number interval is from -1,000,000,000 to 1,000,000,000 and 5 decimal places.  
 To configure this sorting type, write the placeholder that you want to use. That's it.  
@@ -132,6 +133,18 @@ Example:
 scoreboard-teams:
   sorting-types:
     - "PLACEHOLDER_HIGH_TO_LOW:%luckperms_highest_group_weight%"
+```
+
+## GROUPS_OR_PLACEHOLDER
+This method sorts players by their permission group. If the player's group is not listed,
+the output of a placeholder is used instead. This is useful for grouping players by towns
+while still keeping LuckPerms groups on top.
+
+Configuration follows the `%placeholder%:group1,group2` format. Example using a Towny placeholder:
+```yaml
+scoreboard-teams:
+  sorting-types:
+    - "GROUPS_OR_PLACEHOLDER:%townyadvanced_town%:admin,mod,default"
 ```
 
 # Multiple elements with the same priority
@@ -180,7 +193,7 @@ Although you can theoretically use as many sorting types as you want, there are 
 # Additional info
 ## Additional note 1 - Limitations
 All sorting elements must together build a team name up to 16 characters long. Because of that, cuts in placeholder outputs may be required. TAB is already using the shortest possible values for all sorting types:
-* `GROUPS`, `PERMISSIONS` and `PLACEHOLDER` - 1 character
+* `GROUPS`, `PERMISSIONS`, `PLACEHOLDER` and `GROUPS_OR_PLACEHOLDER` - 1 character
 * `PLACEHOLDER_LOW_TO_HIGH` and `PLACEHOLDER_HIGH_TO_LOW` - 3 characters
 * `PLACEHOLDER_A_TO_Z` and `PLACEHOLDER_Z_TO_A` - as many as used
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
@@ -59,6 +59,7 @@ public class Sorting extends RefreshableFeature implements SortingManager, JoinL
         types.put("PLACEHOLDER_Z_TO_A", PlaceholderZtoA::new);
         types.put("PLACEHOLDER_LOW_TO_HIGH", PlaceholderLowToHigh::new);
         types.put("PLACEHOLDER_HIGH_TO_LOW", PlaceholderHighToLow::new);
+        types.put("GROUPS_OR_PLACEHOLDER", GroupsOrPlaceholder::new);
         usedSortingTypes = compile(configuration.getSortingTypes());
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/GroupsOrPlaceholder.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/GroupsOrPlaceholder.java
@@ -1,0 +1,75 @@
+package me.neznamy.tab.shared.features.sorting.types;
+
+import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.shared.TabConstants;
+import me.neznamy.tab.shared.features.sorting.Sorting;
+import me.neznamy.tab.shared.platform.TabPlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Sorting by groups with a fallback placeholder. Players are sorted by group
+ * using configured order. If player's group is not found, output of the
+ * placeholder is used to keep players of the same value together.
+ */
+public class GroupsOrPlaceholder extends SortingType {
+
+    /** Map of sorted groups */
+    private final LinkedHashMap<String, Integer> sortedGroups;
+
+    /** Map of placeholder values to sorting index */
+    private final Map<String, Integer> placeholderPositions = new LinkedHashMap<>();
+
+    /** Next index for unknown placeholder values */
+    private int nextIndex;
+
+    /**
+     * Constructs new instance with given parameters.
+     *
+     * @param   sorting
+     *          Sorting feature
+     * @param   options
+     *          Options in format %placeholder%:group1,group2,...
+     */
+    public GroupsOrPlaceholder(Sorting sorting, String options) {
+        super(sorting, "GROUPS_OR_PLACEHOLDER", extractPlaceholder(options));
+        String[] split = options.split(":", 2);
+        if (split.length == 2) {
+            sortedGroups = convertSortingElements(split[1].split(","));
+        } else {
+            TAB.getInstance().getConfigHelper().startup().invalidSortingLine("GROUPS_OR_PLACEHOLDER:" + options,
+                    "Expected format %placeholder%:group1,group2");
+            sortedGroups = new LinkedHashMap<>();
+        }
+        nextIndex = sortedGroups.size() + 1;
+    }
+
+    private static String extractPlaceholder(String options) {
+        int i = options.indexOf(":");
+        return i == -1 ? options : options.substring(0, i);
+    }
+
+    @Override
+    public String getChars(@NotNull TabPlayer p) {
+        if (!valid) return "";
+        String group = p.getGroup().toLowerCase();
+        int position;
+        if (sortedGroups.containsKey(group) && !group.equals(TabConstants.NO_GROUP)) {
+            position = sortedGroups.get(group);
+            p.sortingData.teamNameNote += "\n-> Primary group (&e" + p.getGroup() + "&r) is &a#" + position + "&r in sorting list.";
+        } else {
+            String value = setPlaceholders(p);
+            String clean = value.trim();
+            if (!sorting.getConfiguration().isCaseSensitiveSorting()) clean = clean.toLowerCase(Locale.US);
+            if (!placeholderPositions.containsKey(clean)) {
+                placeholderPositions.put(clean, nextIndex++);
+            }
+            position = placeholderPositions.get(clean);
+            p.sortingData.teamNameNote += "\n-> " + sortingPlaceholder + " returned \"&e" + value + "&r\".";
+        }
+        return String.valueOf((char) (position + 47));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GroupsOrPlaceholder` sorting type to fall back to placeholder when group not found
- document the new sorting type

## Testing
- `./gradlew :shared:compileJava`


------
https://chatgpt.com/codex/tasks/task_e_685951514f888326bd75227ece94ca4c